### PR TITLE
Making displayed alt text appear different to regular text

### DIFF
--- a/mdsvex.config.js
+++ b/mdsvex.config.js
@@ -2,11 +2,12 @@ import { defineMDSveXConfig as defineConfig } from "mdsvex"
 
 const config = defineConfig({
   extensions: [".svelte.md", ".md", ".svx"],
-
   smartypants: {
+    quotes: true,
+    ellipses: true,
+    backticks: true,
     dashes: "oldschool",
   },
-
   remarkPlugins: [],
   rehypePlugins: [],
 })

--- a/src/lib/styles/base.scss
+++ b/src/lib/styles/base.scss
@@ -73,6 +73,9 @@ li {
 
 img {
   width: 100%;
+  color: var(--color-text-disabled);
+  font-size: var(--font-050);
+  font-style: italic;
 }
 
 code,


### PR DESCRIPTION
Alternate text for broken images now appears differently than regular text.
This makes reading pages with broken images more indicative when images are missing.