### PR TITLE
DEV-16 Stripping trailing slash from feed extension if present

### DIFF
--- a/src/routes/p/feed.[...extension]/+server.ts
+++ b/src/routes/p/feed.[...extension]/+server.ts
@@ -5,7 +5,7 @@ import fetchPosts from "$lib/api/plots/travel"
 export const GET = async ({ params }) => {
   // Limiting feed to the latest 10 posts
   const feed = buildFeed((await fetchPosts()).slice(0, 10))
-  switch (params.extension.toLowerCase()) {
+  switch (params.extension.toLowerCase().replace(/\/+$/, "")) {
     case "json":
       return json(JSON.parse(feed.json1()))
     case "rss":


### PR DESCRIPTION
This is currently an issue only in production.
If RSS feed routes contain a trailing slash, the determination of the proper extension needs to account for that.
This doesn't crop up in development or production preview 😢 