### PR TITLE
DEV-15 Adding support for site-wide metatags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "sass": "^1.69.6",
         "svelte": "^4.2.7",
         "svelte-check": "^3.6.0",
+        "svelte-meta-tags": "^3.1.0",
         "tinygesture": "^3.0.0",
         "tslib": "^2.4.1",
         "typescript": "^5.0.0",
@@ -3792,6 +3793,15 @@
       "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
       "dev": true
     },
+    "node_modules/schema-dts": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.2.tgz",
+      "integrity": "sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -4010,6 +4020,18 @@
       },
       "peerDependencies": {
         "svelte": "^3.19.0 || ^4.0.0"
+      }
+    },
+    "node_modules/svelte-meta-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/svelte-meta-tags/-/svelte-meta-tags-3.1.0.tgz",
+      "integrity": "sha512-wFBfpktSua1R5rdvQ/aFucvXmRqzDhRYrPpMQ/pL4+KL5QHIzomPf29a5WN3yDR0reSy1PXyQ2ah0+uCYCbi0g==",
+      "dev": true,
+      "dependencies": {
+        "schema-dts": "^1.1.2"
+      },
+      "peerDependencies": {
+        "svelte": "^3.55.0 || ^4.0.0"
       }
     },
     "node_modules/svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sass": "^1.69.6",
     "svelte": "^4.2.7",
     "svelte-check": "^3.6.0",
+    "svelte-meta-tags": "^3.1.0",
     "tinygesture": "^3.0.0",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",

--- a/src/app.html
+++ b/src/app.html
@@ -5,15 +5,6 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta property="proven.lol" content="proven3f2375" />
-    <meta property="og:type" content="website" />
-    <meta
-      property="og:description"
-      content="Highly driven software engineer, passionate about building easily sustainable solutions."
-    />
-    <meta
-      property="og:image"
-      content="https://gravatar.com/avatar/02651d15ffdc3bb8e7cb4d20b33b7f1c?s=512"
-    />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -1,6 +1,7 @@
 export const FIRST_NAME = "Stephen"
 export const LAST_NAME = "Bunn"
 export const FULL_NAME = `${FIRST_NAME} ${LAST_NAME}`
+export const AVATAR_URL = "https://gravatar.com/avatar/02651d15ffdc3bb8e7cb4d20b33b7f1c?s=512"
 export const CONTACT_EMAIL = "hiring@bunn.io"
 export const SITE_DOMAIN = "https://bunn.io"
 export const SITE_DESCRIPTION = "Build as intuitively as possible."

--- a/src/lib/utils/metaTags.ts
+++ b/src/lib/utils/metaTags.ts
@@ -1,0 +1,35 @@
+import type { MetaTagsProps } from "svelte-meta-tags"
+import omit from "$lib/utils/omit"
+import {
+  AVATAR_URL,
+  FIRST_NAME,
+  FULL_NAME,
+  SITE_DESCRIPTION,
+  SITE_DOMAIN,
+} from "$lib/utils/constants"
+
+export const buildMetaTags = (
+  route: { id: string | null },
+  overrides: Partial<MetaTagsProps> = {}
+): MetaTagsProps => {
+  const canonical = `${SITE_DOMAIN}${route.id || ""}`
+  return {
+    title: FULL_NAME,
+    description: SITE_DESCRIPTION,
+    canonical,
+    openGraph: {
+      type: "website",
+      url: canonical,
+      images: [
+        {
+          url: AVATAR_URL,
+          alt: `${FIRST_NAME}'s Portrait`,
+          width: 512,
+          height: 512,
+        },
+      ],
+      ...(overrides.openGraph || {}),
+    },
+    ...omit(overrides, "openGraph"),
+  }
+}

--- a/src/lib/utils/omit.ts
+++ b/src/lib/utils/omit.ts
@@ -1,0 +1,3 @@
+export default function omit(obj: object, ...keys: string[]): object {
+  return Object.fromEntries(Object.entries(obj).filter(([key]) => !keys.includes(key)))
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,11 +3,18 @@
   import "$lib/styles/base.scss"
   import Header from "$lib/components/Header.svelte"
   import Footer from "$lib/components/Footer.svelte"
+  import { page } from "$app/stores"
+  import { MetaTags } from "svelte-meta-tags"
+  import { buildMetaTags } from "$lib/utils/metaTags"
+
+  $: metaTags = buildMetaTags($page.route, $page.data.metaTagsOverride)
 </script>
 
 <svelte:head>
   <title>{FIRST_NAME}</title>
 </svelte:head>
+
+<MetaTags {...metaTags} />
 
 <Header />
 <main>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,4 +1,2 @@
 export const prerender = true
-// export const csr = true
-// export const ssr = false
 export const trailingSlash = "always"

--- a/src/routes/colophon/+page.server.ts
+++ b/src/routes/colophon/+page.server.ts
@@ -1,13 +1,19 @@
 const isProduction = import.meta.env.MODE === "production"
 import { CI, GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } from "$env/static/private"
+import { FULL_NAME } from "$lib/utils/constants"
 
-export const load = async () => ({
-  ci: Boolean(CI || false),
-  currentDate: new Date(),
-  github: isProduction
-    ? {
-        actionId: String(GITHUB_RUN_ID),
-        actionUrl: `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`,
-      }
-    : null,
-})
+export const load = async () => {
+  return {
+    ci: Boolean(CI || false),
+    currentDate: new Date(),
+    github: isProduction
+      ? {
+          actionId: String(GITHUB_RUN_ID),
+          actionUrl: `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`,
+        }
+      : null,
+    metaTagsOverride: {
+      title: `${FULL_NAME} - Colophon`,
+    },
+  }
+}

--- a/src/routes/contact/+page.ts
+++ b/src/routes/contact/+page.ts
@@ -1,0 +1,5 @@
+import { FULL_NAME } from "$lib/utils/constants"
+
+export async function load() {
+  return { metaTagsOverride: { title: `${FULL_NAME} - Contact` } }
+}

--- a/src/routes/p/+page.ts
+++ b/src/routes/p/+page.ts
@@ -1,0 +1,9 @@
+import { FULL_NAME } from "$lib/utils/constants"
+
+export const load = async () => {
+  return {
+    metaTagsOverride: {
+      title: `${FULL_NAME} - Plots`,
+    },
+  }
+}

--- a/src/routes/p/travel/+page.ts
+++ b/src/routes/p/travel/+page.ts
@@ -1,5 +1,11 @@
 import type { Post } from "$lib/types/post"
+import { FULL_NAME } from "$lib/utils/constants"
 
 export const load = async ({ fetch }) => {
-  return { posts: (await (await fetch("/api/plots/travel")).json()) as Post[] }
+  return {
+    posts: (await (await fetch("/api/plots/travel")).json()) as Post[],
+    metaTagsOverride: {
+      title: `${FULL_NAME} - Travel`,
+    },
+  }
 }

--- a/src/routes/p/travel/[slug]/+page.ts
+++ b/src/routes/p/travel/[slug]/+page.ts
@@ -1,18 +1,46 @@
 import type { Post } from "$lib/types/post"
+import type { MetaTagsProps } from "svelte-meta-tags"
 import { error } from "@sveltejs/kit"
+import { FULL_NAME, SITE_DOMAIN } from "$lib/utils/constants"
 import { buildPost, getPostPlot } from "$lib/utils/post"
 
-export async function load({
-  params,
-}): Promise<{ post: Post; Content: ConstructorOfATypedSvelteComponent }> {
+export async function load({ params }): Promise<{
+  post: Post
+  metaTagsOverride: MetaTagsProps
+  Content: ConstructorOfATypedSvelteComponent
+}> {
   // We can't pull out this templated string into a shared variable due to a Vite limitation
   // https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations
   const data = await import(`../${params.slug}.svx`)
   const post = buildPost(`../${params.slug}.svx`, data, getPostPlot("travel"))
   if (!post) error(404, "Not found")
 
+  const canonical = `${SITE_DOMAIN}${post.href}`
+  const metaTagsOverride: MetaTagsProps = Object.freeze({
+    title: post.title,
+    description: post.metadata?.description,
+    canonical,
+    openGraph: {
+      type: "article",
+      siteName: FULL_NAME,
+      url: canonical,
+      title: post.title,
+      description: post.metadata?.description,
+      images: post.metadata?.imageUrl
+        ? [{ url: post.metadata.imageUrl, alt: post.metadata?.imageAlt }]
+        : [],
+      article: {
+        publishedTime: post.published.toISOString(),
+        modifiedTime: post.updated.toISOString(),
+        authors: [FULL_NAME],
+        tags: post.metadata?.tags,
+      },
+    },
+  })
+
   return {
     post,
+    metaTagsOverride,
     Content: data.default,
   }
 }

--- a/src/routes/resume/+page.ts
+++ b/src/routes/resume/+page.ts
@@ -1,0 +1,9 @@
+import { FULL_NAME } from "$lib/utils/constants"
+
+export const load = async () => {
+  return {
+    metaTagsOverride: {
+      title: `${FULL_NAME} - Resume`,
+    },
+  }
+}

--- a/src/routes/uses/+page.ts
+++ b/src/routes/uses/+page.ts
@@ -1,0 +1,9 @@
+import { FULL_NAME } from "$lib/utils/constants"
+
+export const load = async () => {
+  return {
+    metaTagsOverride: {
+      title: `${FULL_NAME} - Uses`,
+    },
+  }
+}


### PR DESCRIPTION
Adding support for meta tags that can be dynamically constructed from any route. The current exception to this is the plots slug routes as they need to adapt to a different Open Graph type. This could be pulled out into a different function inside of `$lib/utils/metaTags.ts` if I start needing to repeat myself for different plot routes.