### PR TITLE
DEV-17 Displaying a plot post's completeness as an emoji

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@kurone-kito/jsonresume-types": "^0.4.0",
+        "@svelte-plugins/tooltips": "^3.0.0",
         "@sveltejs/adapter-auto": "^3.0.0",
         "@sveltejs/adapter-static": "^3.0.1",
         "@sveltejs/kit": "^2.0.0",
@@ -826,6 +827,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@svelte-plugins/tooltips": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@svelte-plugins/tooltips/-/tooltips-3.0.0.tgz",
+      "integrity": "sha512-lE7LKU01OY8XYwsWmRxEcBZJqVv+f/TP5JQP5eqzb9ppS9UeN8DF/mFP9i2BfELRfYdwl4qwUENTPYBndMI3LA==",
+      "dev": true,
+      "peerDependencies": {
+        "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-next.0"
+      }
     },
     "node_modules/@sveltejs/adapter-auto": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@kurone-kito/jsonresume-types": "^0.4.0",
+    "@svelte-plugins/tooltips": "^3.0.0",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/adapter-static": "^3.0.1",
     "@sveltejs/kit": "^2.0.0",

--- a/src/lib/components/PostArticle.svelte
+++ b/src/lib/components/PostArticle.svelte
@@ -1,17 +1,35 @@
 <script lang="ts">
+  import { Tooltip } from "@svelte-plugins/tooltips"
   import type { Post } from "$lib/types/post"
+  import { PostStage, getPostStage } from "$lib/utils/post"
   import { formatDate } from "$lib/utils/format"
   import Link from "$lib/components/Link.svelte"
 
   export let post: Post
+  const postStage = getPostStage(post.metadata?.stage)
+
+  let stageEmoji = "🌱"
+  let stageDetail = "Growing; expect many changes"
+  if (postStage === PostStage.BUDDING) {
+    stageEmoji = "🌿"
+    stageDetail = "Taking form; not yet fully grown"
+  } else if (postStage === PostStage.EVERGREEN) {
+    stageEmoji = "🌳"
+    stageDetail = "Fully grown"
+  }
 </script>
 
 <article>
   <h1>{post.title}</h1>
   <span class="detail"
     >Published in <Link small href={post.plot.href}>{post.plot.name}</Link>
-    on {formatDate(post.published, "MMM DD YYYY")}.</span
-  >
+    on {formatDate(post.published, "MMM DD YYYY")}.
+    <span class="stage">
+      <Tooltip content={stageDetail} arrow={false} position="right" maxWidth={300}>
+        {stageEmoji}
+      </Tooltip>
+    </span>
+  </span>
   <slot />
 </article>
 
@@ -24,5 +42,10 @@
     font-size: var(--font-050);
     color: var(--color-text-disabled);
     font-family: var(--font-serif);
+  }
+
+  .stage {
+    margin-left: var(--space-1x);
+    cursor: default;
   }
 </style>

--- a/src/lib/styles/base.scss
+++ b/src/lib/styles/base.scss
@@ -2,6 +2,7 @@
 @use "fonts.scss";
 @use "space.scss";
 @use "code.scss";
+@use "tooltip.scss";
 
 :root {
   --duration-default: 0.2s;

--- a/src/lib/styles/tooltip.scss
+++ b/src/lib/styles/tooltip.scss
@@ -1,0 +1,9 @@
+@use "colors";
+@use "fonts";
+
+:root {
+  --tooltip-font-family: var(--font-sans) !important;
+  --tooltip-background-color: var(--color-surface) !important;
+  --tooltip-color: var(--color-text) !important;
+  --tooltip-box-shadow: 0 5px 20px var(--color-text-disabled) !important;
+}

--- a/src/lib/types/post.d.ts
+++ b/src/lib/types/post.d.ts
@@ -14,6 +14,8 @@ export interface PostMetadata {
   imageUrl?: string
   /** The post's default display image alternate text. */
   imageAlt?: string
+  /** The post's stage. */
+  stage?: string
 }
 
 /** Describes the plot for a given post. */

--- a/src/lib/utils/post.ts
+++ b/src/lib/utils/post.ts
@@ -2,8 +2,37 @@ import type { Post, PostMetadata, PostPlot } from "$lib/types/post"
 import { sanitizeHtml } from "$lib/utils/sanitize"
 import { error } from "@sveltejs/kit"
 
+/** Describes the posts completeness. */
+export enum PostStage {
+  /** Very rough work, to be refined later. */
+  SEEDLING,
+  /** Cleaned up work, will be finalized later. */
+  BUDDING,
+  /** Finalized work, unlikely to change. */
+  EVERGREEN,
+}
+
 /** The supported post plot names. */
 export type PostPlotName = "travel"
+
+/**
+ * Get the appropriate `PostStage` enum from a given string.
+ *
+ * @param postStage The string stage to get as a `PostStage` enum.
+ * @returns The determined `PostStage` enum
+ */
+export const getPostStage = (postStage?: string): PostStage => {
+  if (!postStage) return PostStage.SEEDLING
+
+  switch (postStage.toLowerCase()) {
+    case "budding":
+      return PostStage.BUDDING
+    case "evergreen":
+      return PostStage.EVERGREEN
+    default:
+      return PostStage.SEEDLING
+  }
+}
 
 /**
  * Get the plot structure for a post given a plot's name.


### PR DESCRIPTION
Showing an emoji based on the `stage` metadata parameter for plot posts. This emoji has a tooltip attached that displays the _status_ of the content. The current supported statuses are:

- `seedling`
- `budding`
- `evergreen`

If no status is provided, the new function `getPostStage` defaults to the `seedling` status.